### PR TITLE
Prioritize AMI meter number

### DIFF
--- a/custom_components/acwd_water_usage/sensor.py
+++ b/custom_components/acwd_water_usage/sensor.py
@@ -161,7 +161,14 @@ class AcwdWaterUsage(Entity):
 
         response_json = self.make_api_request(api_url, headers, data)
         if response_json:
-            return response_json.get('MeterDetails', [{}])[0].get('MeterNumber', '')
+            meters = response_json.get("MeterDetails", [{}])
+            # Iterate until we find a meter where 'Advanced Meter Infrastructure' == TRUE
+            for meter in meters:
+                if meter.get("IsAMI"):
+                    return meter.get("MeterNumber", "")
+            # Otherwise, return the first meter
+            return meters[0].get("MeterNumber", "")
+
         _LOGGER.warning("Meter details failed: No response data")
         return None
 


### PR DESCRIPTION
I was unable to obtain any data from this library because my account has two meters on it. It looks like I have an older non-smart meter (which begins with a letter) which only contains monthly billing info, but also a new smart meter which allows detailed hourly info. 

This PR will prioritize using an AMI 'smart meter' for the library, but fall back to the previous behavior of picking the first available meter if no smart meter is found. 